### PR TITLE
iss 10 fix - NRE when using pre .netcore proj

### DIFF
--- a/src/RiskFirst.Hateoas/LinksServicesCollectionExtensions.cs
+++ b/src/RiskFirst.Hateoas/LinksServicesCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
+using RiskFirst.Hateoas.Polyfills;
 
 namespace RiskFirst.Hateoas
 {
@@ -13,6 +14,7 @@ namespace RiskFirst.Hateoas
             if (services == null)
                 throw new ArgumentNullException(nameof(services));
 
+            services.TryAddSingleton<IAssemblyLoader, DefaultAssemblyLoader>();
             services.TryAddSingleton<IActionContextAccessor, ActionContextAccessor>();
             //services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.TryAdd(ServiceDescriptor.Transient<IRouteMap, DefaultRouteMap>());

--- a/src/RiskFirst.Hateoas/Polyfills/DefaultAssemblyLoader.cs
+++ b/src/RiskFirst.Hateoas/Polyfills/DefaultAssemblyLoader.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
+
+namespace RiskFirst.Hateoas.Polyfills
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Default implementation for .Net Standard
+    /// </summary>
+    /// <seealso cref="T:RiskFirst.Hateoas.Polyfills.IAssemblyLoader" />
+    internal class DefaultAssemblyLoader : IAssemblyLoader
+    {
+        public IEnumerable<Assembly> GetAssemblies()
+        {
+            var thisAssembly = GetType().GetTypeInfo().Assembly.GetName().Name;
+            var libraries =
+                DependencyContext.Default
+                    .CompileLibraries
+                    .Where(l => l.Dependencies.Any(d => d.Name.Equals(thisAssembly)));
+
+            var names = libraries.Select(l => l.Name).Distinct();
+            var assemblies = names.Select(a => Assembly.Load(new AssemblyName(a)));
+            return assemblies;
+        }
+    }
+}

--- a/src/RiskFirst.Hateoas/Polyfills/IAssemblyLoader.cs
+++ b/src/RiskFirst.Hateoas/Polyfills/IAssemblyLoader.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace RiskFirst.Hateoas.Polyfills
+{
+    /// <summary>
+    /// Abstracts AppDomain functionallity 
+    /// </summary>
+    public interface IAssemblyLoader
+    {
+        IEnumerable<Assembly> GetAssemblies();
+    }
+}

--- a/src/RiskFirst.Hateoas/Properties/AssemblyInfo.cs
+++ b/src/RiskFirst.Hateoas/Properties/AssemblyInfo.cs
@@ -17,3 +17,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ad523ab1-1548-4a2e-80f3-7b2997c60d65")]
+
+[assembly: InternalsVisibleTo("RiskFirst.Hateoas.Tests")]

--- a/tests/RiskFirst.Hateoas.Tests/Controllers/Models/ValueInfo.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Controllers/Models/ValueInfo.cs
@@ -1,0 +1,10 @@
+﻿using RiskFirst.Hateoas.Models;
+
+namespace RiskFirst.Hateoas.Tests.Controllers.Models
+{
+    public class ValueInfo : LinkContainer
+    {
+        public int Id { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/tests/RiskFirst.Hateoas.Tests/Controllers/ValuesController.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Controllers/ValuesController.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using RiskFirst.Hateoas.Models;
+using RiskFirst.Hateoas.Tests.Controllers.Models;
+
+namespace RiskFirst.Hateoas.Tests.Controllers
+{
+    [Route("api/[controller]")]
+    public class ValuesController : Controller
+    {
+        public const string GetAllValuesRoute = "GetAllValuesRoute";
+
+        // GET api/values
+        [HttpGet(Name = "GetAllValuesRoute")]
+        public Task<ItemsLinkContainer<ValueInfo>> Get()
+        {
+            return Task.FromResult(new ItemsLinkContainer<ValueInfo>());
+        }
+    }
+}

--- a/tests/RiskFirst.Hateoas.Tests/DefaultRouteMapTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/DefaultRouteMapTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RiskFirst.Hateoas.Polyfills;
+using RiskFirst.Hateoas.Tests.Controllers;
+using RiskFirst.Hateoas.Tests.Infrastructure;
+using Xunit;
+
+namespace RiskFirst.Hateoas.Tests
+{
+    [Trait("Category", "RouteMap")]
+    public class DefaultRouteMapTests
+    {
+        [AutonamedFact]
+        public void GivenAssemblyLoaderProvidesControllerAssemblies_RoutesAreRegistered()
+        {
+            var contextAccessorMock = new Mock<IActionContextAccessor>();
+            var loggerMock = new Mock<ILogger<DefaultRouteMap>>();
+
+            var routeMap = new DefaultRouteMap(contextAccessorMock.Object, loggerMock.Object, new DefaultAssemblyLoader());
+            var route = routeMap.GetRoute(ValuesController.GetAllValuesRoute);
+            Assert.NotNull(route);
+        }
+    }
+}

--- a/tests/RiskFirst.Hateoas.Tests/Polyfills/DefaultAssemblyLoaderTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Polyfills/DefaultAssemblyLoaderTests.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Reflection;
+using RiskFirst.Hateoas.Polyfills;
+using RiskFirst.Hateoas.Tests.Infrastructure;
+using Xunit;
+
+namespace RiskFirst.Hateoas.Tests.Polyfills
+{
+    [Trait("Category", "Polyfills")]
+    public class DefaultAssemblyLoaderTests
+    {
+        [AutonamedFact]
+        public void WhenGetAssemblies_ShouldReturnAssemblies()
+        {
+            var loader = new DefaultAssemblyLoader();
+            var assemblies = loader.GetAssemblies();
+
+            assemblies.First(a => a.FullName == GetType().GetTypeInfo().Assembly.FullName);
+        }
+    }
+}

--- a/tests/RiskFirst.Hateoas.Tests/RiskFirst.Hateoas.Tests.csproj
+++ b/tests/RiskFirst.Hateoas.Tests/RiskFirst.Hateoas.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
     <PackageReference Include="Moq" Version="4.7.8" />


### PR DESCRIPTION
added IAssemblyLoader and moved the existing impl as default

In case you need to override it, create your own impl and register it before initializing the hateoas lib code like this - services.AddSingleton<IAssemblyLoader, MyAssemblyLoader>()