### PR TITLE
Updated DefaultRouteMap to include Web Api controllers.

### DIFF
--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/RiskFirst.Hateoas.BasicSample.csproj
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/RiskFirst.Hateoas.BasicSample.csproj
@@ -15,17 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateos.BasicSample.Tests/RiskFirst.Hateos.BasicSample.Tests.csproj
+++ b/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateos.BasicSample.Tests/RiskFirst.Hateos.BasicSample.Tests.csproj
@@ -12,11 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="microsoft.net.test.sdk" Version="15.3.0" />
-    <PackageReference Include="system.net.http" Version="4.3.3" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="microsoft.net.test.sdk" Version="15.9.0" />
+    <PackageReference Include="system.net.http" Version="4.3.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/RiskFirst.Hateoas.CustomRequirementSample/src/RiskFirst.Hateoas.CustomRequirementSample/RiskFirst.Hateoas.CustomRequirementSample.csproj
+++ b/Samples/RiskFirst.Hateoas.CustomRequirementSample/src/RiskFirst.Hateoas.CustomRequirementSample/RiskFirst.Hateoas.CustomRequirementSample.csproj
@@ -15,17 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/RiskFirst.Hateoas.LinkConfigurationSample/src/RiskFirst.Hateoas.LinkConfigurationSample/RiskFirst.Hateoas.LinkConfigurationSample.csproj
+++ b/Samples/RiskFirst.Hateoas.LinkConfigurationSample/src/RiskFirst.Hateoas.LinkConfigurationSample/RiskFirst.Hateoas.LinkConfigurationSample.csproj
@@ -15,17 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RiskFirst.Hateoas.Models/RiskFirst.Hateoas.Models.csproj
+++ b/src/RiskFirst.Hateoas.Models/RiskFirst.Hateoas.Models.csproj
@@ -25,7 +25,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="newtonsoft.json" Version="10.0.3" />
+      <PackageReference Include="newtonsoft.json" Version="11.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/RiskFirst.Hateoas/DefaultRouteMap.cs
+++ b/src/RiskFirst.Hateoas/DefaultRouteMap.cs
@@ -34,7 +34,7 @@ namespace RiskFirst.Hateoas
             foreach (var asm in assemblies)
             {
                 var controllers = asm.GetTypes()
-                    .Where(type => typeof(Controller).IsAssignableFrom(type));
+                    .Where(type => typeof(ControllerBase).IsAssignableFrom(type));
 
                 var controllerMethods = controllers.SelectMany(c => c.GetMethods(BindingFlags.Public | BindingFlags.Instance)
                                                                      .Where(m => m.IsDefined(typeof(HttpMethodAttribute)))

--- a/src/RiskFirst.Hateoas/RiskFirst.Hateoas.csproj
+++ b/src/RiskFirst.Hateoas/RiskFirst.Hateoas.csproj
@@ -33,11 +33,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RiskFirst.Hateoas.Tests/Controllers/ApiController.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Controllers/ApiController.cs
@@ -1,17 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using RiskFirst.Hateoas.Models;
 using RiskFirst.Hateoas.Tests.Controllers.Models;
 
 namespace RiskFirst.Hateoas.Tests.Controllers
 {
-    [Route("api/[controller]")]
-    public class ValuesController : Controller
+    [Controller]
+    public class ApiController : ControllerBase
     {
-        public const string GetAllValuesRoute = "GetAllValuesRoute";
+        public const string GetAllValuesRoute = "GetAllValuesApiRoute";
 
         // GET api/values
-        [HttpGet(Name = "GetAllValuesRoute")]
+        [HttpGet(Name = "GetAllValuesApiRoute")]
         public Task<ItemsLinkContainer<ValueInfo>> Get()
         {
             return Task.FromResult(new ItemsLinkContainer<ValueInfo>());

--- a/tests/RiskFirst.Hateoas.Tests/Controllers/ApiController.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Controllers/ApiController.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using RiskFirst.Hateoas.Models;
 using RiskFirst.Hateoas.Tests.Controllers.Models;
+using System.Threading.Tasks;
 
 namespace RiskFirst.Hateoas.Tests.Controllers
 {
-    [Controller]
+    [ApiController]
     public class ApiController : ControllerBase
     {
         public const string GetAllValuesRoute = "GetAllValuesApiRoute";

--- a/tests/RiskFirst.Hateoas.Tests/Controllers/MvcController.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Controllers/MvcController.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using RiskFirst.Hateoas.Models;
+using RiskFirst.Hateoas.Tests.Controllers.Models;
+
+namespace RiskFirst.Hateoas.Tests.Controllers
+{
+    [Route("api/[controller]")]
+    public class MvcController : Controller
+    {
+        public const string GetAllValuesRoute = "GetAllValuesRoute";
+
+        // GET api/values
+        [HttpGet(Name = "GetAllValuesRoute")]
+        public Task<ItemsLinkContainer<ValueInfo>> Get()
+        {
+            return Task.FromResult(new ItemsLinkContainer<ValueInfo>());
+        }
+    }
+}

--- a/tests/RiskFirst.Hateoas.Tests/DefaultRouteMapTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/DefaultRouteMapTests.cs
@@ -18,7 +18,19 @@ namespace RiskFirst.Hateoas.Tests
             var loggerMock = new Mock<ILogger<DefaultRouteMap>>();
 
             var routeMap = new DefaultRouteMap(contextAccessorMock.Object, loggerMock.Object, new DefaultAssemblyLoader());
-            var route = routeMap.GetRoute(ValuesController.GetAllValuesRoute);
+            var route = routeMap.GetRoute(MvcController.GetAllValuesRoute);
+            Assert.NotNull(route);
+        }
+
+
+        [AutonamedFact]
+        public void GivenAssemblyLoaderProvidesApiControllerAssemblies_RoutesAreRegistered()
+        {
+            var contextAccessorMock = new Mock<IActionContextAccessor>();
+            var loggerMock = new Mock<ILogger<DefaultRouteMap>>();
+
+            var routeMap = new DefaultRouteMap(contextAccessorMock.Object, loggerMock.Object, new DefaultAssemblyLoader());
+            var route = routeMap.GetRoute(ApiController.GetAllValuesRoute);
             Assert.NotNull(route);
         }
     }

--- a/tests/RiskFirst.Hateoas.Tests/RiskFirst.Hateoas.Tests.csproj
+++ b/tests/RiskFirst.Hateoas.Tests/RiskFirst.Hateoas.Tests.csproj
@@ -13,13 +13,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
-    <PackageReference Include="Moq" Version="4.7.142" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.utility" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
   </ItemGroup>
 


### PR DESCRIPTION
The DefaultRouteMap implementation was scanning for types which are assignable from Controller, however the [recommended approach](https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-2.1) for Web Api controllers is to inherit from ControllerBase,  so the controllers inheriting from ControllerBase were being missed.