### PR TITLE
XML serialization now works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,28 +69,41 @@ public class MyController : Controller
 
 The above code would produce a response as the example below
 
-```javascript
+```json
 {
-   id:1,
-   someOtherField: "foo",
-   _links : {
-    self: {
-      rel: "MyController\GetModelRoute",
-      href: "https://api.example.com/my/1"
-      method: "GET"
+   "id": 1,
+   "someOtherField": "foo",
+   "_links" : {
+    "self": {
+      "rel": "MyController\\GetModelRoute",
+      "href": "https://api.example.com/my/1",
+      "method": "GET"
     },
-    all: {
-      rel: "MyController\GetAllModelsRoute",
-      href: "https://api.example.com/my"
-      method: "GET"
+    "all": {
+      "rel": "MyController\\GetAllModelsRoute",
+      "href": "https://api.example.com/my",
+      "method": "GET"
     },
-    delete: {
-      rel: "MyController\DeleteModelRoute",
-      href: "https://api.example.com/my/1"
-      method: "DELETE"
+    "delete": {
+      "rel": "MyController\\DeleteModelRoute",
+      "href": "https://api.example.com/my/1",
+      "method": "DELETE"
     }
   }
 }
+```
+
+or if you're using XML
+
+```xml
+<?xml version="1.0"?>
+<MyModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <link href="https://api.example.com/my/1" method="GET" rel="self"/>
+  <link href="https://api.example.com/my" method="GET" rel="all"/>
+  <link href="https://api.example.com/my/1" method="DELETE" rel="delete"/>
+  <Id>1</Id>
+  <SomeOtherField>foo</SomeOtherField>
+</MyModel>
 ```
 
 ### Multiple policies for a model

--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Controllers/ValuesController.cs
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Controllers/ValuesController.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using RiskFirst.Hateoas.BasicSample.Models;
-using RiskFirst.Hateoas.Models;
 using RiskFirst.Hateoas.BasicSample.Repository;
+using RiskFirst.Hateoas.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace RiskFirst.Hateoas.BasicSample.Controllers
 {
@@ -22,6 +20,7 @@ namespace RiskFirst.Hateoas.BasicSample.Controllers
         }
 
         // GET api/values
+        [FormatFilter]
         [HttpGet( Name = "GetAllValuesRoute")]
         public async Task<ItemsLinkContainer<ValueInfo>> Get()
         {
@@ -36,6 +35,7 @@ namespace RiskFirst.Hateoas.BasicSample.Controllers
         }
 
         // GET api/values/5
+        [FormatFilter]
         [HttpGet("{id}", Name = "GetValueByIdRoute")]
         [HttpGet("v2/{id}", Name = "GetValueByIdRouteV2")]
         [Links(Policy = "FullInfoPolicy")]

--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Models/ValueInfo.cs
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Models/ValueInfo.cs
@@ -1,8 +1,4 @@
 ﻿using RiskFirst.Hateoas.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace RiskFirst.Hateoas.BasicSample.Models
 {

--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/RiskFirst.Hateoas.BasicSample.csproj
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/RiskFirst.Hateoas.BasicSample.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />

--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Startup.cs
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Startup.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RiskFirst.Hateoas.BasicSample.Models;
-using RiskFirst.Hateoas.Models;
 using RiskFirst.Hateoas.BasicSample.Repository;
-using System.Reflection;
+using RiskFirst.Hateoas.Models;
+using System.Net.Http.Headers;
 
 namespace RiskFirst.Hateoas.BasicSample
 {
     public class Startup
-    {       
+    {
         public Startup(IHostingEnvironment env)
         {
             var builder = new ConfigurationBuilder()
@@ -35,18 +32,18 @@ namespace RiskFirst.Hateoas.BasicSample
             {
                 // Uncomment the next line to use relative hrefs instead of absolute
                 //config.UseRelativeHrefs();
-               
+
                 config.AddPolicy<ValueInfo>(policy =>
                 {
                     policy.RequireRoutedLink("self", "GetValueByIdRoute", x => new { id = x.Id });
                 });
-                config.AddPolicy<ValueInfo>("FullInfoPolicy",policy =>
-                {
-                    policy.RequireSelfLink()
-                            .RequireRoutedLink("update", "GetValueByIdRoute", x => new { id = x.Id })
-                            .RequireRoutedLink("delete", "DeleteValueRoute", x => new { id = x.Id })
-                            .RequireRoutedLink("all", "GetAllValuesRoute");
-                });
+                config.AddPolicy<ValueInfo>("FullInfoPolicy", policy =>
+                 {
+                     policy.RequireSelfLink()
+                             .RequireRoutedLink("update", "GetValueByIdRoute", x => new { id = x.Id })
+                             .RequireRoutedLink("delete", "DeleteValueRoute", x => new { id = x.Id })
+                             .RequireRoutedLink("all", "GetAllValuesRoute");
+                 });
 
                 config.AddPolicy<ItemsLinkContainer<ValueInfo>>(policy =>
                 {
@@ -54,8 +51,14 @@ namespace RiskFirst.Hateoas.BasicSample
                             .RequireRoutedLink("insert", "InsertValueRoute");
                 });
             });
+
             // Add framework services.
-            services.AddMvc();
+            services.AddMvc(options =>
+            {
+                options.OutputFormatters.Add(new XmlSerializerOutputFormatter());
+                options.FormatterMappings.SetMediaTypeMappingForFormat("xml", MediaTypeHeaderValue.Parse("application/xml").MediaType);
+                options.FormatterMappings.SetMediaTypeMappingForFormat("json", MediaTypeHeaderValue.Parse("application/json").MediaType);
+            });
 
             services.AddSingleton<IValuesRepository, ValuesRepository>();
         }

--- a/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateos.BasicSample.Tests/LinksTests.cs
+++ b/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateos.BasicSample.Tests/LinksTests.cs
@@ -1,41 +1,84 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using System.Net.Http;
-using Xunit;
-using RiskFirst.Hateoas.BasicSample;
 using Newtonsoft.Json;
+using RiskFirst.Hateoas.BasicSample;
 using RiskFirst.Hateoas.BasicSample.Models;
-using System.Collections.Generic;
+using RiskFirst.Hateoas.Models;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using Xunit;
 
 namespace RiskFirst.Hateos.BasicSample.Tests
 {
     public class LinksTests
     {
-        private readonly TestServer server;
         private readonly HttpClient client;
+        private readonly TestServer server;
+
         public LinksTests()
         {
             // Arrange
             server = new TestServer(new WebHostBuilder().UseStartup<Startup>());
             client = server.CreateClient();
         }
+
         [Fact]
-        public async Task GetAllValues_ReturnsObjectsWithLinks()
+        public async Task GetAllValues_Json_ReturnsObjectsWithLinks()
         {
             // Act
             var response = await client.GetAsync("/api/values");
             response.EnsureSuccessStatusCode();
-            
-            var responseString = await response.Content.ReadAsStringAsync();
-            var values = JsonConvert.DeserializeObject<ValuesContainer>(responseString);
 
-            Assert.All(values.Items, i => Assert.True(i.Links.Count>0,"Invalid number of links"));
+            var responseString = await response.Content.ReadAsStringAsync();
+            var values = JsonConvert.DeserializeObject<ItemsLinkContainer<ValueInfo>>(responseString);
+
+            Assert.All(values.Items, i => Assert.True(i.Links.Count > 0, "Invalid number of links"));
         }
 
         [Fact]
-        public async Task GetValue_ReturnsObjectsWithLinks()
+        public async Task GetAllValues_Xml_ReturnsObjectsWithLinks()
+        {
+            // Act
+            var response = await client.GetAsync("/api/values?format=xml");
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var values = DeserializeXml<ItemsLinkContainer<ValueInfo>>(responseString);
+
+            Assert.All(values.Items, i => Assert.True(i.Links.Count > 0, "Invalid number of links"));
+        }
+
+        [Fact]
+        public async Task GetValue_Json_AlternateRoute_ReturnsObjectsWithLinks()
+        {
+            // Act
+            var response = await client.GetAsync("/api/values/v2/1");
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var value = JsonConvert.DeserializeObject<ValueInfo>(responseString);
+
+            Assert.True(value.Links.Count > 0, "Invalid number of links");
+        }
+
+        [Fact]
+        public async Task GetValue_Xml_AlternateRoute_ReturnsObjectsWithLinks()
+        {
+            // Act
+            var response = await client.GetAsync("/api/values/v2/1?format=xml");
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var value = DeserializeXml<ValueInfo>(responseString);
+
+            Assert.True(value.Links.Count > 0, "Invalid number of links");
+        }
+
+        [Fact]
+        public async Task GetValue_Json_ReturnsObjectsWithLinks()
         {
             // Act
             var response = await client.GetAsync("/api/values/1");
@@ -48,21 +91,32 @@ namespace RiskFirst.Hateos.BasicSample.Tests
         }
 
         [Fact]
-        public async Task GetValue_AlternateRoute_ReturnsObjectsWithLinks()
+        public async Task GetValue_Xml_ReturnsObjectsWithLinks()
         {
             // Act
-            var response = await client.GetAsync("/api/values/v2/1");
+            var response = await client.GetAsync("/api/values/1?format=xml");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
-            var value = JsonConvert.DeserializeObject<ValueInfo>(responseString);
+            var value = DeserializeXml<ValueInfo>(responseString);
 
             Assert.True(value.Links.Count > 0, "Invalid number of links");
         }
-    }
 
-    public class ValuesContainer
-    {
-        public IEnumerable<ValueInfo> Items { get; set; }
+        private static T DeserializeXml<T>(string xml)
+        {
+            using (var reader = new StringReader(xml))
+            {
+                XmlSerializer serializer = new XmlSerializer(typeof(T));
+                return (T)serializer.Deserialize(reader);
+            }
+        }
+
+        private static XmlDocument GetDocument(string xml)
+        {
+            var doc = new XmlDocument();
+            doc.Load(xml);
+            return doc;
+        }
     }
 }

--- a/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateos.BasicSample.Tests/LinksTests.cs
+++ b/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateos.BasicSample.Tests/LinksTests.cs
@@ -107,16 +107,9 @@ namespace RiskFirst.Hateos.BasicSample.Tests
         {
             using (var reader = new StringReader(xml))
             {
-                XmlSerializer serializer = new XmlSerializer(typeof(T));
+                var serializer = new XmlSerializer(typeof(T));
                 return (T)serializer.Deserialize(reader);
             }
-        }
-
-        private static XmlDocument GetDocument(string xml)
-        {
-            var doc = new XmlDocument();
-            doc.Load(xml);
-            return doc;
         }
     }
 }

--- a/src/RiskFirst.Hateoas.Models/ILinkContainer.cs
+++ b/src/RiskFirst.Hateoas.Models/ILinkContainer.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-
-namespace RiskFirst.Hateoas.Models
+﻿namespace RiskFirst.Hateoas.Models
 {
     public interface ILinkContainer
     {
-        Dictionary<string, Link> Links { get; set; }
-        void AddLink(string id, Link link);
+        LinkCollection Links { get; set; }
+        void Add(Link link);
     }
 }

--- a/src/RiskFirst.Hateoas.Models/Link.cs
+++ b/src/RiskFirst.Hateoas.Models/Link.cs
@@ -1,9 +1,21 @@
-﻿namespace RiskFirst.Hateoas.Models
+﻿using Newtonsoft.Json;
+using System.Xml.Serialization;
+
+namespace RiskFirst.Hateoas.Models
 {
     public class Link
     {
-        public string Rel { get; set; }
+        [XmlAttribute("href")]
         public string Href { get; set; }
+
+        [XmlAttribute("method")]
         public string Method { get; set; }
+
+        [XmlAttribute("rel")]
+        [JsonIgnore]
+        public string Name { get; set; }
+
+        [XmlIgnore]
+        public string Rel { get; set; }
     }
 }

--- a/src/RiskFirst.Hateoas.Models/LinkCollection.cs
+++ b/src/RiskFirst.Hateoas.Models/LinkCollection.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace RiskFirst.Hateoas.Models
+{
+    [JsonConverter(typeof(LinkCollectionConverter))]
+    public class LinkCollection : IEnumerable<Link>
+    {
+        private readonly Dictionary<string, Link> links = new Dictionary<string, Link>();
+
+        public int Count => links.Count;
+
+        public void Add(Link link) =>
+           links.Add(link.Name, link);
+
+        public bool ContainsKey(string key) =>
+            links.ContainsKey(key);
+
+        public IEnumerator<Link> GetEnumerator() =>
+            links.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+
+        public Link this[string name]
+        {
+            get => links[name];
+            set => links[name] = value;
+        }
+    }
+}

--- a/src/RiskFirst.Hateoas.Models/LinkCollectionConverter.cs
+++ b/src/RiskFirst.Hateoas.Models/LinkCollectionConverter.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RiskFirst.Hateoas.Models
+{
+    public class LinkCollectionConverter : JsonConverter<LinkCollection>
+    {
+        public override LinkCollection ReadJson(JsonReader reader, Type objectType, LinkCollection existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var links = (Dictionary<string, Link>)serializer
+                .Deserialize(reader, typeof(Dictionary<string, Link>));
+
+            foreach (var link in links)
+            {
+                link.Value.Name = link.Key;
+                existingValue.Add(link.Value);
+            }
+
+            return existingValue;
+        }
+
+        public override void WriteJson(JsonWriter writer, LinkCollection value, JsonSerializer serializer)
+        {
+            var links = value?
+                .ToDictionary(x => x.Name, x => x);
+
+            serializer.Serialize(writer, links);
+        }
+    }
+}

--- a/src/RiskFirst.Hateoas.Models/LinkContainer.cs
+++ b/src/RiskFirst.Hateoas.Models/LinkContainer.cs
@@ -1,23 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Newtonsoft.Json;
+using System.Xml.Serialization;
 
 namespace RiskFirst.Hateoas.Models
 {
     public abstract class LinkContainer : ILinkContainer
     {
-        private Dictionary<string, Link> links;
+        [XmlElement("link")]
         [JsonProperty(PropertyName = "_links")]
-        public Dictionary<string, Link> Links
-        {
-            get { return links ?? (links = new Dictionary<string, Link>()); }
+        public LinkCollection Links { get; set; } = new LinkCollection();
 
-            set { links = value; }
-        }
-
-        public void AddLink(string id, Link link)
+        public void Add(Link link)
         {
-            Links.Add(id, link);
+            Links.Add(link);
         }
     }
 }

--- a/src/RiskFirst.Hateoas/DefaultLinksEvaluator.cs
+++ b/src/RiskFirst.Hateoas/DefaultLinksEvaluator.cs
@@ -14,6 +14,7 @@ namespace RiskFirst.Hateoas
             this.options = options.Value;
             this.contextFactory = contextFactory;
         }
+
         public void BuildLinks(IEnumerable<ILinkSpec> links, ILinkContainer container)
         {
             foreach (var link in links)
@@ -21,8 +22,9 @@ namespace RiskFirst.Hateoas
                 var context = contextFactory.CreateContext(link);
                 try
                 {
-                    container.AddLink(link.Id, new Link()
+                    container.Add(new Link()
                     {
+                        Name = link.Id,
                         Href = options.HrefTransformation?.Transform(context),
                         Rel = options.RelTransformation?.Transform(context),
                         Method = link.HttpMethod.ToString()

--- a/tests/RiskFirst.Hateoas.Tests/JsonSerializationTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/JsonSerializationTests.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using RiskFirst.Hateoas.Models;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace RiskFirst.Hateoas.Tests
+{
+    public class JsonSerializationTests
+    {
+        [Fact]
+        public void WhenLinksAreAvailable_ShouldSerializeThemProperly()
+        {
+            // Arrange
+            var testLinks = new List<Link>
+            {
+                new Link { Name = "self", Href = "https://myamazingapp.com/12", Method = "GET", Rel = "self-rel" },
+                new Link { Name = "create", Href = "https://myamazingapp.com/create", Method = "POST", Rel = "create-rel" },
+                new Link { Name = "delete", Href = "https://myamazingapp.com/delete", Method = "DELETE", Rel = "delete-rel" }
+            };
+
+            var container = new TestLinkContainer(testLinks);
+
+            // Act
+            var result = JsonConvert.SerializeObject(container);
+
+            // Assert
+            var deserialized = JsonConvert.DeserializeObject<TestLinkContainer>(result);
+
+            Assert.True(deserialized.Links.Count > 0);
+
+            var linksAreCorrect = deserialized.Links.All(l => testLinks
+                .Any(tl => tl.Href == l.Href &&
+                           tl.Method == l.Method &&
+                           tl.Name == l.Name &&
+                           tl.Rel == l.Rel));
+
+            Assert.True(linksAreCorrect);
+        }
+
+        [Fact]
+        public void WhenNoLinksAreAvailable_NoLinksShouldBeSerialized()
+        {
+            // Arrange
+            var testLinks = Enumerable.Empty<Link>();
+
+            var container = new TestLinkContainer(testLinks);
+
+            // Act
+            var result = JsonConvert.SerializeObject(container);
+
+            // Assert
+            var deserialized = JsonConvert.DeserializeObject<TestLinkContainer>(result);
+
+            Assert.Equal(0, deserialized.Links.Count);
+        }
+    }
+}

--- a/tests/RiskFirst.Hateoas.Tests/TestLinkContainers.cs
+++ b/tests/RiskFirst.Hateoas.Tests/TestLinkContainers.cs
@@ -1,39 +1,50 @@
 ﻿using RiskFirst.Hateoas.Models;
+using System.Collections.Generic;
 
 namespace RiskFirst.Hateoas.Tests
 {
-    public class TestLinkContainer : LinkContainer
-    {
-        public int Id { get; set; }
-        public TestLinkContainer()
-        {
-        }
-    }
-
     public class DerivedLinkContainer : TestLinkContainer { }
-
-    public class UnrelatedLinkContainer : LinkContainer { }
-
-
-    [Links(Policy = "OverridePolicy")]
-    public class OverrideTestLinkContainer : LinkContainer
-    {
-        public int Id { get; set; }
-        public OverrideTestLinkContainer()
-        {
-        }
-    }
 
     [Links()]
     public class EmptyOverrideTestLinkContainer : LinkContainer
     {
-        public int Id { get; set; }
         public EmptyOverrideTestLinkContainer()
         {
         }
+
+        public int Id { get; set; }
+    }
+
+    [Links(Policy = "OverridePolicy")]
+    public class OverrideTestLinkContainer : LinkContainer
+    {
+        public OverrideTestLinkContainer()
+        {
+        }
+
+        public int Id { get; set; }
+    }
+
+    public class TestLinkContainer : LinkContainer
+    {
+        public TestLinkContainer()
+        {
+        }
+
+        public TestLinkContainer(IEnumerable<Link> links)
+        {
+            foreach (var link in links)
+            {
+                Links.Add(link);
+            }
+        }
+
+        public int Id { get; set; }
     }
 
     public class TestPagedLinkContainer : PagedItemsLinkContainer<TestLinkContainer>
     {
     }
+
+    public class UnrelatedLinkContainer : LinkContainer { }
 }

--- a/tests/RiskFirst.Hateoas.Tests/XmlSerizalizationTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/XmlSerizalizationTests.cs
@@ -61,18 +61,18 @@ namespace RiskFirst.Hateoas.Tests
         {
             using (var reader = new StringReader(xml))
             {
-                XmlSerializer serializer = new XmlSerializer(typeof(T));
+                var serializer = new XmlSerializer(typeof(T));
                 return (T)serializer.Deserialize(reader);
             }
         }
 
         private static string SerializeToXml(object obj)
         {
-            XmlSerializer xsSubmit = new XmlSerializer(obj.GetType());
+            var serializer = new XmlSerializer(obj.GetType());
 
             using (var writer = new StringWriter())
             {
-                xsSubmit.Serialize(writer, obj);
+                serializer.Serialize(writer, obj);
                 return writer.ToString();
             }
         }

--- a/tests/RiskFirst.Hateoas.Tests/XmlSerizalizationTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/XmlSerizalizationTests.cs
@@ -1,0 +1,80 @@
+﻿using RiskFirst.Hateoas.Models;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace RiskFirst.Hateoas.Tests
+{
+    public class XmlSerizalizationTests
+    {
+        [Fact]
+        public void WhenLinksAreAvailable_ShouldSerializeThemProperly()
+        {
+            // Arrange
+            var testLinks = new List<Link>
+            {
+                new Link { Name = "self", Href = "https://myamazingapp.com/12", Method = "GET", Rel = "self-rel" },
+                new Link { Name = "create", Href = "https://myamazingapp.com/create", Method = "POST", Rel = "create-rel" },
+                new Link { Name = "delete", Href = "https://myamazingapp.com/delete", Method = "DELETE", Rel = "delete-rel" }
+            };
+
+            var container = new TestLinkContainer(testLinks);
+
+            // Act
+            var xml = SerializeToXml(container);
+
+            // Assert
+            var result = DeserializeXml<TestLinkContainer>(xml);
+
+            Assert.Equal(result.Links.Count, testLinks.Count);
+
+            var linksAreCorrect = result.Links.All(l => testLinks
+                .Any(tl => tl.Href == l.Href &&
+                           tl.Method == l.Method &&
+                           // We purposefully skip comparing by Rel because we expect it to be lost
+                           // during the serialization/deserialization (and that's ok)
+                           tl.Name == l.Name));
+
+            Assert.True(linksAreCorrect);
+        }
+
+        [Fact]
+        public void WhenNoLinksAreAvailable_NoLinksShouldBeSerialized()
+        {
+            // Arrange
+            var testLinks = Enumerable.Empty<Link>();
+
+            var container = new TestLinkContainer(testLinks);
+
+            // Act
+            var xml = SerializeToXml(container);
+
+            // Assert
+            var result = DeserializeXml<TestLinkContainer>(xml);
+
+            Assert.Equal(0, result.Links.Count);
+        }
+
+        private static T DeserializeXml<T>(string xml)
+        {
+            using (var reader = new StringReader(xml))
+            {
+                XmlSerializer serializer = new XmlSerializer(typeof(T));
+                return (T)serializer.Deserialize(reader);
+            }
+        }
+
+        private static string SerializeToXml(object obj)
+        {
+            XmlSerializer xsSubmit = new XmlSerializer(obj.GetType());
+
+            using (var writer = new StringWriter())
+            {
+                xsSubmit.Serialize(writer, obj);
+                return writer.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
+ Added standalone tests for the json/xml serialization. ([xml](https://github.com/riskfirst/riskfirst.hateoas/compare/master...dnikolovv:xml-serialization?expand=1#diff-ef1d952f1d8bea83fc4f2c13bf17ec99), [json](https://github.com/riskfirst/riskfirst.hateoas/compare/master...dnikolovv:xml-serialization?expand=1#diff-c8b133164c97c84557a0650cf77caff3))
+ Added XML format support in the `BasicSample` project's `ValuesController` and tests that check whether links are returned when fetching data with `?format=xml`. ([here](https://github.com/riskfirst/riskfirst.hateoas/compare/master...dnikolovv:xml-serialization?expand=1#diff-33677b83653c3f1b717a1b612df19bb0))

The JSON serialization logic remains unchanged.

The XML format used is this one (note that the "controller details" are lost while serializing to XML and the link name is put inside the `rel` attribute).

```xml
<?xml version="1.0"?>
<ItemsLinkContainerOfValueInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <link href="http://localhost/api/Values" method="GET" rel="self"/>
  <link href="http://localhost/api/Values" method="POST" rel="insert"/>
  <Items>
    <ValueInfo>
      <link href="http://localhost/api/Values/1" method="GET" rel="self"/>
      <Id>1</Id>
      <Value>Value One</Value>
    </ValueInfo>
    <ValueInfo>
      <link href="http://localhost/api/Values/2" method="GET" rel="self"/>
      <Id>2</Id>
      <Value>Value Two</Value>
    </ValueInfo>
    <ValueInfo>
      <link href="http://localhost/api/Values/3" method="GET" rel="self"/>
      <Id>3</Id>
      <Value>Value Three</Value>
    </ValueInfo>
  </Items>
</ItemsLinkContainerOfValueInfo>
```

Closes https://github.com/riskfirst/riskfirst.hateoas/issues/17 and https://github.com/riskfirst/riskfirst.hateoas/issues/25.