### PR TITLE
Add optional scheme arg to AddProtocol

### DIFF
--- a/src/RiskFirst.Hateoas/LinkTransformationBuilderExtensions.cs
+++ b/src/RiskFirst.Hateoas/LinkTransformationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,15 +8,15 @@ namespace RiskFirst.Hateoas
 {
     public static class LinkTransformationBuilderExtensions
     {
-        public static LinkTransformationBuilder AddProtocol(this LinkTransformationBuilder builder)
+        public static LinkTransformationBuilder AddProtocol(this LinkTransformationBuilder builder, string scheme = null)
         {
-            return builder.Add(ctx => String.Concat(ctx.HttpContext.Request.Scheme, "://"));
+            return builder.Add(ctx => String.Concat(scheme ?? ctx.HttpContext.Request.Scheme, "://"));
         }
 
         public static LinkTransformationBuilder AddHost(this LinkTransformationBuilder builder)
         {
             return builder.Add(ctx => ctx.HttpContext.Request.Host.ToUriComponent());
-        }      
+        }
 
         public static LinkTransformationBuilder AddRoutePath(this LinkTransformationBuilder builder)
         {
@@ -35,7 +35,7 @@ namespace RiskFirst.Hateoas
         }
         public static LinkTransformationBuilder AddVirtualPath(this LinkTransformationBuilder builder,string path)
         {
-            return builder.AddVirtualPath(ctx => path);            
+            return builder.AddVirtualPath(ctx => path);
         }
         public static LinkTransformationBuilder AddVirtualPath(this LinkTransformationBuilder builder,Func<LinkTransformationContext, string> getPath)
         {

--- a/tests/RiskFirst.Hateoas.Tests/Infrastructure/TestCaseBuilder.cs
+++ b/tests/RiskFirst.Hateoas.Tests/Infrastructure/TestCaseBuilder.cs
@@ -22,7 +22,7 @@ namespace RiskFirst.Hateoas.Tests.Infrastructure
         private IRouteMap routeMap;
         private LinksOptions options = new LinksOptions();
         private List<ILinksHandler> handlers = new List<ILinksHandler>() { new PassThroughLinksHandler() };
-       
+
         private Mock<HttpContext> httpContextMock = new Mock<HttpContext>();
         private Mock<HttpRequest> requestMock = new Mock<HttpRequest>();
         private RouteData routeData = new RouteData();
@@ -97,6 +97,12 @@ namespace RiskFirst.Hateoas.Tests.Infrastructure
         public TestCaseBuilder WithQueryParams(Dictionary<string, StringValues> queryParams = null)
         {
             requestMock.Setup(r => r.Query).Returns(new QueryCollection(queryParams));
+            return this;
+        }
+
+        public TestCaseBuilder WithRequestScheme(string scheme)
+        {
+            requestMock.Setup(r => r.Scheme).Returns(scheme);
             return this;
         }
 


### PR DESCRIPTION
Adds an optional argument to allow the request scheme to be overridden with a static value. 

This is useful when you want all links to be `https`, but your requests aren't (for example, your service is running behind a load balancer with ssl termination).

Currently, to support this requires a custom `Add` call:
```
config.ConfigureHrefTransformation(t => t.Add($"{Uri.UriSchemeHttps}://").AddHost().AddRoutePath());
```

This change allows for:
```
config.ConfigureHrefTransformation(t => t.AddProtocol(Uri.UriSchemeHttps).AddHost().AddRoutePath());
```