### PR TITLE
Change to use RunTimeLibraries as CompileLibraries is empty for net6 …

### DIFF
--- a/src/RiskFirst.Hateoas/Polyfills/DefaultAssemblyLoader.cs
+++ b/src/RiskFirst.Hateoas/Polyfills/DefaultAssemblyLoader.cs
@@ -17,7 +17,7 @@ namespace RiskFirst.Hateoas.Polyfills
             var thisAssembly = GetType().GetTypeInfo().Assembly.GetName().Name;
             var libraries =
                 DependencyContext.Default
-                    .CompileLibraries
+                    .RuntimeLibraries
                     .Where(l => l.Dependencies.Any(d => d.Name.Equals(thisAssembly)));
 
             var names = libraries.Select(l => l.Name).Distinct();


### PR DESCRIPTION
…after publishing

After updating to .net6 we realized that all of our attached links were no longer being added to responses.
Oddly enough when running locally (in debug) the links worked fine.
After some investigation we found that the routeMap was empty for the deployed system. This was because CompileLibraries was not populated.

Switching to RunTimeLibraries works for both debugging and the published app. All tests still pass as expected.

For further context we publish with `dotnet publish XXX -c Release -r linux-x64 -v q`.