### PR TITLE
[v5.0.0] using System.Text.Json instead of Newtonsoft.Json

### DIFF
--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Program.cs
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/Program.cs
@@ -12,7 +12,6 @@ public partial class Program
         var services = builder.Services;
 
         services.AddControllers()
-            .AddNewtonsoftJson()
             .AddXmlSerializerFormatters();
         services.AddScoped<IValuesRepository, ValuesRepository>();
         services.AddLinks(config =>

--- a/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/RiskFirst.Hateoas.BasicSample.csproj
+++ b/Samples/RiskFirst.Hateoas.BasicSample/src/RiskFirst.Hateoas.BasicSample/RiskFirst.Hateoas.BasicSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -7,9 +7,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\RiskFirst.Hateoas\RiskFirst.Hateoas.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.2" />
   </ItemGroup>
 </Project>

--- a/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateoas.BasicSample.Tests/RiskFirst.Hateoas.BasicSample.Tests.csproj
+++ b/Samples/RiskFirst.Hateoas.BasicSample/tests/RiskFirst.Hateoas.BasicSample.Tests/RiskFirst.Hateoas.BasicSample.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Samples/RiskFirst.Hateoas.CustomRequirementSample/src/RiskFirst.Hateoas.CustomRequirementSample/Program.cs
+++ b/Samples/RiskFirst.Hateoas.CustomRequirementSample/src/RiskFirst.Hateoas.CustomRequirementSample/Program.cs
@@ -13,8 +13,7 @@ public partial class Program
 
         var services = builder.Services;
 
-        services.AddControllers()
-            .AddNewtonsoftJson();
+        services.AddControllers();
 
         services.AddTransient<ILinksHandler, ApiRootLinkHandler>();
         services.AddScoped<IValuesRepository, ValuesRepository>();

--- a/Samples/RiskFirst.Hateoas.CustomRequirementSample/src/RiskFirst.Hateoas.CustomRequirementSample/RiskFirst.Hateoas.CustomRequirementSample.csproj
+++ b/Samples/RiskFirst.Hateoas.CustomRequirementSample/src/RiskFirst.Hateoas.CustomRequirementSample/RiskFirst.Hateoas.CustomRequirementSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -8,9 +8,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\RiskFirst.Hateoas\RiskFirst.Hateoas.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.2" />
   </ItemGroup>
 </Project>

--- a/Samples/RiskFirst.Hateoas.CustomRequirementSample/tests/RiskFirst.Hateoas.CustomRequirementsSample.Tests/LinkTests.cs
+++ b/Samples/RiskFirst.Hateoas.CustomRequirementSample/tests/RiskFirst.Hateoas.CustomRequirementsSample.Tests/LinkTests.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Mvc.Testing;
-using Newtonsoft.Json;
 using RiskFirst.Hateoas.CustomRequirementSample.Models;
 using RiskFirst.Hateoas.CustomRequirementsSample.Tests;
 using RiskFirst.Hateoas.Models;
+using System.Net.Http.Json;
 
 namespace RiskFirst.Hateoas.CustomRequirementsSample.TestsNew;
 
@@ -23,11 +23,9 @@ public class RootApiTests
         var client = _factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/api/values");
-        response.EnsureSuccessStatusCode();
+        var test = await client.GetStringAsync("/api/values");
 
-        var responseString = await response.Content.ReadAsStringAsync();
-        var values = JsonConvert.DeserializeObject<ItemsLinkContainer<ValueInfo>>(responseString);
+        var values = await client.GetFromJsonAsync<ItemsLinkContainer<ValueInfo>>("/api/values");
 
         Assert.Contains(
             new Link

--- a/Samples/RiskFirst.Hateoas.CustomRequirementSample/tests/RiskFirst.Hateoas.CustomRequirementsSample.Tests/RiskFirst.Hateoas.CustomRequirementsSample.Tests.csproj
+++ b/Samples/RiskFirst.Hateoas.CustomRequirementSample/tests/RiskFirst.Hateoas.CustomRequirementsSample.Tests/RiskFirst.Hateoas.CustomRequirementsSample.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Samples/RiskFirst.Hateoas.LinkConfigurationSample/src/RiskFirst.Hateoas.LinkConfigurationSample/Program.cs
+++ b/Samples/RiskFirst.Hateoas.LinkConfigurationSample/src/RiskFirst.Hateoas.LinkConfigurationSample/Program.cs
@@ -12,8 +12,7 @@ public partial class Program
 
         var services = builder.Services;
 
-        services.AddControllers()
-            .AddNewtonsoftJson();
+        services.AddControllers();
         services.AddScoped<IValuesRepository, ValuesRepository>();
         services.AddLinks(config =>
         {

--- a/Samples/RiskFirst.Hateoas.LinkConfigurationSample/src/RiskFirst.Hateoas.LinkConfigurationSample/RiskFirst.Hateoas.LinkConfigurationSample.csproj
+++ b/Samples/RiskFirst.Hateoas.LinkConfigurationSample/src/RiskFirst.Hateoas.LinkConfigurationSample/RiskFirst.Hateoas.LinkConfigurationSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -8,9 +8,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\RiskFirst.Hateoas\RiskFirst.Hateoas.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.2" />
   </ItemGroup>
 </Project>

--- a/src/RiskFirst.Hateoas.Models/Link.cs
+++ b/src/RiskFirst.Hateoas.Models/Link.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace RiskFirst.Hateoas.Models

--- a/src/RiskFirst.Hateoas.Models/LinkCollection.cs
+++ b/src/RiskFirst.Hateoas.Models/LinkCollection.cs
@@ -1,6 +1,6 @@
-﻿using Newtonsoft.Json;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace RiskFirst.Hateoas.Models
 {

--- a/src/RiskFirst.Hateoas.Models/LinkCollectionConverter.cs
+++ b/src/RiskFirst.Hateoas.Models/LinkCollectionConverter.cs
@@ -1,16 +1,18 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace RiskFirst.Hateoas.Models
 {
     public class LinkCollectionConverter : JsonConverter<LinkCollection>
     {
-        public override LinkCollection ReadJson(JsonReader reader, Type objectType, LinkCollection existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override LinkCollection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var links = (Dictionary<string, Link>)serializer
-                .Deserialize(reader, typeof(Dictionary<string, Link>));
+            var links = JsonSerializer.Deserialize<Dictionary<string, Link>>(ref reader, options);
+
+            var existingValue = new LinkCollection();
 
             foreach (var link in links)
             {
@@ -21,12 +23,11 @@ namespace RiskFirst.Hateoas.Models
             return existingValue;
         }
 
-        public override void WriteJson(JsonWriter writer, LinkCollection value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, LinkCollection value, JsonSerializerOptions options)
         {
-            var links = value?
-                .ToDictionary(x => x.Name, x => x);
+            var links = value?.ToDictionary(x => x.Name, x => x);
 
-            serializer.Serialize(writer, links);
+            JsonSerializer.Serialize(writer, links);
         }
     }
 }

--- a/src/RiskFirst.Hateoas.Models/LinkContainer.cs
+++ b/src/RiskFirst.Hateoas.Models/LinkContainer.cs
@@ -1,13 +1,12 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
+using System.Text.Json.Serialization;
 
 namespace RiskFirst.Hateoas.Models
 {
     public abstract class LinkContainer : ILinkContainer
     {
         [XmlElement("link")]
-        [JsonProperty(PropertyName = "_links")]
+        [JsonPropertyName("_links")]
         public LinkCollection Links { get; set; } = new LinkCollection();
 
         public void Add(Link link)

--- a/src/RiskFirst.Hateoas.Models/RiskFirst.Hateoas.Models.csproj
+++ b/src/RiskFirst.Hateoas.Models/RiskFirst.Hateoas.Models.csproj
@@ -21,15 +21,16 @@
             v3.1.1 - version bump to match main assembly
             v3.1.2 - Patch Security Issues
             v4.0.0 - version bump to match main assembly
+            v5.0.0 - using System.Text.Json
         </PackageReleaseNotes>
-        <Version>4.0.0</Version>
+        <Version>5.0.0</Version>
         <PackageIconUrl>https://raw.githubusercontent.com/riskfirst/pkgicons/master/riskfirst-pkg.png</PackageIconUrl>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <FileVersion>4.0.0.0</FileVersion>
+        <AssemblyVersion>5.0.0.0</AssemblyVersion>
+        <FileVersion>5.0.0.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="newtonsoft.json" Version="13.0.2" />
+      <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
 </Project>

--- a/src/RiskFirst.Hateoas/RiskFirst.Hateoas.csproj
+++ b/src/RiskFirst.Hateoas/RiskFirst.Hateoas.csproj
@@ -29,11 +29,12 @@
         v3.1.1 - bug fix for routes with more than 1 HttpMethodAttribute
         v3.1.2 - Patch Security Issues
         v4.0.0 - Drop .NET Framework support
+        v5.0.0 - RiskFirst.Hateoas.Models v5.0.0
     </PackageReleaseNotes>
-    <Version>4.0.0</Version>
+    <Version>5.0.0</Version>
     <PackageIconUrl>https://raw.githubusercontent.com/riskfirst/pkgicons/master/riskfirst-pkg.png</PackageIconUrl>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <FileVersion>5.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/RiskFirst.Hateoas.Tests/JsonSerializationTests.cs
+++ b/tests/RiskFirst.Hateoas.Tests/JsonSerializationTests.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using RiskFirst.Hateoas.Models;
+﻿using RiskFirst.Hateoas.Models;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Xunit;
 
 namespace RiskFirst.Hateoas.Tests
@@ -22,10 +22,10 @@ namespace RiskFirst.Hateoas.Tests
             var container = new TestLinkContainer(testLinks);
 
             // Act
-            var result = JsonConvert.SerializeObject(container);
+            var result = JsonSerializer.Serialize(container);
 
             // Assert
-            var deserialized = JsonConvert.DeserializeObject<TestLinkContainer>(result);
+            var deserialized = JsonSerializer.Deserialize<TestLinkContainer>(result);
 
             Assert.True(deserialized.Links.Count > 0);
 
@@ -47,10 +47,10 @@ namespace RiskFirst.Hateoas.Tests
             var container = new TestLinkContainer(testLinks);
 
             // Act
-            var result = JsonConvert.SerializeObject(container);
+            var result = JsonSerializer.Serialize(container);
 
             // Assert
-            var deserialized = JsonConvert.DeserializeObject<TestLinkContainer>(result);
+            var deserialized = JsonSerializer.Deserialize<TestLinkContainer>(result);
 
             Assert.Equal(0, deserialized.Links.Count);
         }


### PR DESCRIPTION
`System.Text.Json` Serialization is the default for ASP.NET Core applications therefor this MR changes to `System.Text.Json` and removes `Newtonsoft.Json` references.